### PR TITLE
Feat#8 명함관련 API 수정. 임시로 memberId 받아오던 것을 userPrincipal을 받아오도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // swagger 세팅
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     //@postconstruct 때문에 javax에서 jakarta 필요해서
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 //redis 연결을 위해 필요

--- a/src/main/java/com/example/cardcase/card/CardController.java
+++ b/src/main/java/com/example/cardcase/card/CardController.java
@@ -4,6 +4,8 @@ import com.example.cardcase.card.dto.CardDetailResponse;
 import com.example.cardcase.card.dto.CardSummaryResponse;
 import com.example.cardcase.common.apiPayload.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
@@ -20,19 +22,24 @@ public class CardController {
      */
     @GetMapping
     public ApiResponse<List<CardSummaryResponse>> getMyCardList(
-            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
-            @RequestParam Long memberId // 임시 파라미터
+            @AuthenticationPrincipal User userPrincipal
     ) {
-        List<CardSummaryResponse> cardList = cardService.getCardList(memberId);
+        String memberEmail = userPrincipal.getUsername();
+
+        List<CardSummaryResponse> cardList = cardService.getCardList(memberEmail);
         return ApiResponse.success(cardList);
     }
 
     /**
-     * 공유 받은 명함 상세 조회 API
+     * 명함 상세 조회 API
      */
     @GetMapping("/{cardId}")
-    public ApiResponse<CardDetailResponse> getCardDetail(@PathVariable Long cardId) {
-        CardDetailResponse cardDetail = cardService.getCardDetail(cardId);
+    public ApiResponse<CardDetailResponse> getCardDetail(
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal User userPrincipal
+    ) {
+        String memberEmail = userPrincipal.getUsername();
+        CardDetailResponse cardDetail = cardService.getCardDetail(memberEmail, cardId);
         return ApiResponse.success(cardDetail);
     }
 
@@ -42,10 +49,10 @@ public class CardController {
     @DeleteMapping("/{cardId}/my-case")
     public ApiResponse<?> removeCardFromMyCase(
             @PathVariable Long cardId,
-            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
-            @RequestParam Long memberId // 임시 파라미터
+            @AuthenticationPrincipal User userPrincipal
     ) {
-        cardService.removeCardFromMyCase(memberId, cardId);
+        String memberEmail = userPrincipal.getUsername();
+        cardService.removeCardFromMyCase(memberEmail, cardId);
         return ApiResponse.success();
     }
 
@@ -55,11 +62,10 @@ public class CardController {
     @DeleteMapping("/{cardId}")
     public ApiResponse<?> deleteBusinessCard(
             @PathVariable Long cardId,
-            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
-            @RequestParam Long memberId // 임시 파라미터
+            @AuthenticationPrincipal User userPrincipal
     ) throws AccessDeniedException {
-        // TODO: 삭제하더라도 공유받은 사람은 정보를 볼 수 있어야 한다??
-        cardService.deleteBusinessCard(memberId, cardId);
+        String memberEmail = userPrincipal.getUsername();
+        cardService.deleteBusinessCard(memberEmail, cardId);
         return ApiResponse.success();
     }
 }

--- a/src/main/java/com/example/cardcase/card/CardService.java
+++ b/src/main/java/com/example/cardcase/card/CardService.java
@@ -10,9 +10,7 @@ import com.example.cardcase.common.apiPayload.error.CoreException;
 import com.example.cardcase.common.apiPayload.error.GlobalErrorType;
 import com.example.cardcase.oauth.domain.entity.Member;
 import com.example.cardcase.oauth.repository.MemberRepository; // Member 조회를 위해 필요
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,7 +75,7 @@ public class CardService {
      * 명함 원본 삭제
      */
     @Transactional
-    public void deleteBusinessCard(String memberEmail, Long cardId) throws AccessDeniedException {
+    public void deleteBusinessCard(String memberEmail, Long cardId) {
         BusinessCard businessCard = findBusinessCardById(cardId);
         Member member = findMemberByEmail(memberEmail);
         if (businessCard.getMember().equals(member)) {

--- a/src/main/java/com/example/cardcase/card/CardService.java
+++ b/src/main/java/com/example/cardcase/card/CardService.java
@@ -34,7 +34,6 @@ public class CardService {
      * 공유받은 명함 상세 조회
      */
     public List<CardSummaryResponse> getCardList(String memberEmail) {
-        System.out.println(memberEmail);
         Member member = findMemberByEmail(memberEmail);
         List<Relation> relations = relationRepository.findByMember(member);
 

--- a/src/main/java/com/example/cardcase/card/CardService.java
+++ b/src/main/java/com/example/cardcase/card/CardService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/example/cardcase/card/repository/RelationRepository.java
+++ b/src/main/java/com/example/cardcase/card/repository/RelationRepository.java
@@ -1,5 +1,6 @@
 package com.example.cardcase.card.repository;
 
+import com.example.cardcase.card.entity.BusinessCard;
 import com.example.cardcase.card.entity.Relation;
 import com.example.cardcase.oauth.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,7 +11,6 @@ import java.util.Optional;
 
 public interface RelationRepository extends JpaRepository<Relation, Long> {
     List<Relation> findByMember(Member member);
-
+    void deleteByBusinessCard(BusinessCard businessCard);
     Optional<Relation> findByMemberAndBusinessCardId(Member member, Long businessCardId);
-
 }

--- a/src/main/java/com/example/cardcase/common/apiPayload/error/GlobalErrorType.java
+++ b/src/main/java/com/example/cardcase/common/apiPayload/error/GlobalErrorType.java
@@ -10,7 +10,7 @@ public enum GlobalErrorType implements ErrorType {
 
     E500(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
     MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Member Not Found."), // "존재하지 않는 사용자" 401 Unauthorized
-    NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    NOT_ALLOWED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
     ;
 

--- a/src/main/java/com/example/cardcase/common/apiPayload/error/GlobalErrorType.java
+++ b/src/main/java/com/example/cardcase/common/apiPayload/error/GlobalErrorType.java
@@ -10,6 +10,8 @@ public enum GlobalErrorType implements ErrorType {
 
     E500(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
     MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Member Not Found."), // "존재하지 않는 사용자" 401 Unauthorized
+    NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/cardcase/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/cardcase/common/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))   // 세션을 사용하지 않도록 설정(JWT는 Stateless 방식이므로 세션 필요 없음)
                 .authorizeHttpRequests(auth -> auth     // 요청에 대한 인가(Authorization) 설정
                         .dispatcherTypeMatchers(ERROR).permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()  // 로그인과 회원가입은 인증 없이 접근 가능
                         // requestMatchers를 추가해 API를 통한 필터링 가능
                         .anyRequest().authenticated()   // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/example/cardcase/oauth/domain/entity/Member.java
+++ b/src/main/java/com/example/cardcase/oauth/domain/entity/Member.java
@@ -18,8 +18,9 @@ import java.util.List;
 @Entity
 @Table(name = "member") // 테이블명 멤버로
 public class Member {
+
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;


### PR DESCRIPTION
### 🍀 Issue Number
close : #8 

### 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 :
- [ ] 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 :


### 🍀 기대 결과



### 🍀 전달사항
- CardController에서 `Long memberId` 를 받아서 cardService로 넘겨주던 것에서 `@Authentication userPrincipal`을 통해 `memberEmail`을 받아와 service에서 memberRepository에서 멤버를 조회하도록 수정했습니다.
- 명함 상세조회, 명함 삭제 등에서 권한 확인 로직이 없어 추가해주었습니다.
- 스웨거가 작동하도록 버전을 최신버전으로 올려주었고 시큐리티에서 관련 url을 허용해주었습니다.
- 내 명함 삭제시 relation에서도 명함이 삭제되도록 수정했습니다.
- 내 명함 삭제시 백업 서버에 원본을 둘 것 같아 임시로 `businessCard.disown()` 함수를 사용하여 member와의 연관을 끊도록 수정했습니다.
- GlobalErrorType도 만들어 연결했습니다.


### 🍀 스크린샷


